### PR TITLE
Feat/display filtered mockdata

### DIFF
--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -24,7 +24,7 @@ class App extends Component<{}, AppState> {
 fetchResults = (event: React.MouseEvent<HTMLButtonElement>, formState: {selectedCnt : string, selectedType : string}) => {
   event.preventDefault()
   const filteredData = mockData.recordings.filter(data => 
-       data.cnt === this.state.currentCnt && data.type.includes(this.state.currentType)) 
+       data.cnt === formState.selectedCnt && data.type.includes(formState.selectedType)) 
     console.log(filteredData)
   this.setState({searchResults: filteredData})  
     console.log(this.state)
@@ -40,7 +40,7 @@ render() {
          <MainPage selectedCnt={this.state.currentCnt} selectedType={this.state.currentType} fetchResults={this.fetchResults} />
         </Route>
         <Route exact path="/results">
-          <SearchResults />
+          <SearchResults results={this.state.searchResults} />
         </Route>
       </Switch>
     </div>

--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -4,6 +4,7 @@ import Header from '../Header/Header'
 import SearchResults from '../SearchResults/SearchResults'
 import { Route, Switch } from 'react-router-dom'
 import mockData from '../../MockData/mock-data.json'
+import { data } from 'cypress/types/jquery'
 
 type AppState = {
   count: number
@@ -22,8 +23,12 @@ class App extends Component<{}, AppState> {
 
 fetchResults = (event: React.MouseEvent<HTMLButtonElement>, formState: {selectedCnt : string, selectedType : string}) => {
   event.preventDefault()
-  console.log(formState.selectedCnt, formState.selectedType)
-  console.log("Chirp Chirp API Call:", mockData)
+  const filteredData = mockData.recordings.filter(data => 
+       data.cnt === this.state.currentCnt && data.type.includes(this.state.currentType)) 
+    console.log(filteredData)
+  this.setState({searchResults: filteredData})  
+    console.log(this.state)
+ 
   }
 
 render() {

--- a/src/Components/Form/Form.tsx
+++ b/src/Components/Form/Form.tsx
@@ -15,7 +15,7 @@ type FormState = {
 
 class Form extends Component<FormProps, FormState> {
   state = {
-    selectedCnt: '',
+    selectedCnt: 'United States',
     selectedType: ''
   }
 
@@ -35,7 +35,7 @@ class Form extends Component<FormProps, FormState> {
             <label className='continent-label'>
               Continent:
               <select className='country' name='country' onChange={event => this.setState({selectedCnt : event.target.value})}>
-                <option value="usa">United States</option>
+                <option value="United States">United States</option>
                 <option value='africa'>Africa</option>
                 <option value='america'>Americas</option>
                 <option value='asia'>Asia</option>

--- a/src/Components/SearchResults/SearchResults.css
+++ b/src/Components/SearchResults/SearchResults.css
@@ -1,3 +1,4 @@
 .search-results {
+  margin: 3em;
   
 }

--- a/src/Components/SearchResults/SearchResults.tsx
+++ b/src/Components/SearchResults/SearchResults.tsx
@@ -22,7 +22,7 @@ const SearchResults = ({ results }: SearchResultsProps) => {
   return (
     <section className="search-results">
       <h1> Results from your search</h1>
-      <u>
+      <ul>
           {results.map((result) => (
             <li key={result.id}>
               <p>{result.en}</p>
@@ -33,7 +33,7 @@ const SearchResults = ({ results }: SearchResultsProps) => {
               <p>{result.cnt}</p>
             </li>
           ))}
-      </u>
+      </ul>
     </section>
   )
 }

--- a/src/Components/SearchResults/SearchResults.tsx
+++ b/src/Components/SearchResults/SearchResults.tsx
@@ -1,12 +1,39 @@
 import React from 'react'
 import './SearchResults.css'
 
-const SearchResults = () => {
+type Result = {
+  id: string;
+  en: string;
+  stage: string;
+  sex: string;
+  type: string;
+  file: string;
+  cnt: string;
 
+
+}
+
+type SearchResultsProps = {
+  results: Array<Result>;
+}
+
+const SearchResults = ({ results }: SearchResultsProps) => {
 
   return (
     <section className="search-results">
-      <h1> Router Stuff Happened</h1>
+      <h1> Results from your search</h1>
+      <u>
+          {results.map((result) => (
+            <li key={result.id}>
+              <p>{result.en}</p>
+              <p>{result.stage}</p>
+              <p>{result.sex}</p>
+              <p>{result.type}</p>
+              <p>{result.file}</p>
+              <p>{result.cnt}</p>
+            </li>
+          ))}
+      </u>
     </section>
   )
 }

--- a/src/MockData/mock-data.json
+++ b/src/MockData/mock-data.json
@@ -18,7 +18,7 @@
 "lat": "27.667",
 "lng": "-81.3566",
 "alt": "20",
-"type": "dawn song, song",
+"type": "dawn-song",
 "sex": "male",
 "stage": "adult",
 "method": "field recording",


### PR DESCRIPTION
## 🛠️ Description of this branch

* renders filtered mock data to the results page
* fixes and updates branch called feat/searchresults_bug

- [X] New Feature
- [X] Fix
- [ ] Documentation
- [ ] Tests

## 🧠 Context or Rationale for this code
###### What is helpful for team to know and understand about decisions made in this code. 
fetchResults was comparing our data to empty strings in the state. We may not need to keep the user's choices for search filters in the state. Because now fetchResults compares the mock data directly to the inputs gathered from the form. I saved the search results in state. then passed them as a prop down to the Search Results component. 


## 👀 Checks
- [X] When the project is run locally, the terminal shows no errors or warnings
- [X] Breaks nothing
- [ ] Breaks some things & Creates new issues
- [ ] Code in this branch has been tested  
- [X] Forgot to write new tests for changes in this code, but it is added to the project board as a ticket. 
- [ ] Code is DRY, reusable, follows SRP and trends toward function purity 
- [ ] I've updated the project board to reflect changes, add issues, or tickets


## ✍🏽 Notes, Questions, What's Next

Next up: 
making the cards to render the search result data
figuring out how to deal with the audio files to listen to them. 

## Screenshot

![image](https://github.com/sdmisra/birdWords/assets/117617970/1eddb59f-94b0-4109-ba85-782dc75d9e02)
