### PR TITLE
feat: Add more details to the individual bird card that a user clicks…

### DIFF
--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -21,6 +21,13 @@ type birdObject = {
   stage: string;
   sex: string;
   songType: string;
+  loc: string;
+  date: string;
+  rec: string;
+  also: string;
+  rmk: string;
+  osci: string;
+  sono: string;
 }
 
 class App extends Component<{}, AppState> {
@@ -28,14 +35,14 @@ class App extends Component<{}, AppState> {
     currentCnt: "",
     currentType: "",
     searchResults: [],
-    chosenBird: {id:'', en:'', cnt:'', file:'', stage:'', sex:'', songType:''}
+    chosenBird: {id:'', en:'', cnt:'', file:'', stage:'', sex:'', songType:'', loc:'', date:'', rec:'', also:'',  rmk:'', osci:'', sono:'' }
   }
 
   fetchResults = (event: React.MouseEvent<HTMLButtonElement>, formState: {selectedCnt : string, selectedType : string}) => {
       event.preventDefault()
       FetchConditional(formState.selectedCnt, formState.selectedType)
       .then(data => {
-        this.setState({ searchResults: data})
+        this.setState({ searchResults: data })
       })
   }
   
@@ -45,7 +52,7 @@ class App extends Component<{}, AppState> {
     foundBird ? 
       this.setState({chosenBird: foundBird}) 
       : 
-      this.setState({chosenBird: {id:'', en:'', cnt:'', file:'', stage:'', sex:'', songType:''}});
+      this.setState({chosenBird: {id:'', en:'', cnt:'', file:'', stage:'', sex:'', songType:'', loc:'', date:'', rec:'', also:'',  rmk:'', osci:'', sono:'' }});
 
     console.log('App state at time of click:', this.state.chosenBird);
   }
@@ -71,6 +78,7 @@ class App extends Component<{}, AppState> {
           <Route path='/info/:id'>
             <BirdInfo 
             chosenBird={this.state.chosenBird}
+            
             />
           </Route>
         </Switch>

--- a/src/Components/BirdInfo/BirdInfo.css
+++ b/src/Components/BirdInfo/BirdInfo.css
@@ -3,17 +3,20 @@
 }
 
 .bird {
- height: 50em;
+ height: 80%;
 }
 
 .bird-data-container {
   border: .2rem solid#4B7F52;
   display: flex;
   justify-content: center;
-  flex-direction: column-reverse;
+  flex-direction: column;
   border-radius: 10px;
-  width: 17em;
+  min-width: 40%;
+  height: 80%;
   align-items: center;
+  margin: 2rem;
+
 }
 
 .audio-details-container {
@@ -36,6 +39,16 @@
 .osci-image:hover {
   opacity: 0.8;
   transform: scale(1.1);
+}
+
+.sono-image {
+  height: 80px;
+  width: 60%;
+  margin-top: 10%;
+  transition: opacity 0.3s ease-in-out;
+   border: 2px solid #4B7F52;
+  border-radius: 50%;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 @media (max-width: 320px) {

--- a/src/Components/BirdInfo/BirdInfo.tsx
+++ b/src/Components/BirdInfo/BirdInfo.tsx
@@ -13,24 +13,42 @@ type birdObject = {
   file: string;
   stage: string;
   sex: string;
-  songType: string;
+  type: string;
+  loc: string;
+  date: string;
+  rec: string;
+  also: string;
+  rmk: string;
+  osci: {med: string};
 }
 
-const BirdInfo = (props : BirdProps ) => {
-  console.log(props.chosenBird.en)
+const BirdInfo = ({ chosenBird }:
+BirdProps ) => {
+
+  console.log("Chosen", chosenBird)
     return ( 
       <div className="info-container">
         <img className="bird" src={assets} alt="two birds looking at you from a branch"></img>
         <section className="bird-data-container">
-          <h2>{props.chosenBird.en}</h2>
-          <p>{props.chosenBird.cnt}</p>
+          <h2>{chosenBird.en}</h2>
+          <p></p>
+          <p>{chosenBird.stage}</p>
+          <p>{chosenBird.sex}</p>
+          <p>{chosenBird.type}</p>
+            <p>In the background listen for: {chosenBird.also}</p>
+          <p>Recorded in {chosenBird.cnt} at {chosenBird.loc}</p>
+          <p>on {chosenBird.date}</p>
+          <p>Recorded by {chosenBird.rec}</p>
+          <p>Notes from the recorder: {chosenBird.rmk}</p>
+        
         </section>
         <section className="audio-details-container">
-          <audio src='https://xeno-canto.org/524792/download' controls className="bird-info-audio"></audio>
-          <img className="osci-image" src={"//xeno-canto.org/sounds/uploaded/MLTFMFCXEO/wave/XC524792-med.png"} alt="recording of birdsong shown as a visual graph"></img>
+          <audio src={chosenBird.file} controls className="bird-info-audio"></audio>
+          <img className="osci-image" src={chosenBird.osci.med} alt="recording of birdsong shown as a visual graph"></img>
         </section>
       </div>
     )
-}
+  }
+
 
 export default BirdInfo;

--- a/src/Components/SearchResults/SearchResults.tsx
+++ b/src/Components/SearchResults/SearchResults.tsx
@@ -2,9 +2,6 @@ import React from 'react'
 import './SearchResults.css'
 import ResultCard from "../ResultCard/ResultCard"
 
-
-
-
 type Result = {
   id: string;
   en: string;
@@ -20,7 +17,7 @@ type SearchResultsProps = {
   getInfo: (id:string) => void
 }
 
-const SearchResults = ({ results, getInfo }: SearchResultsProps) => {
+const SearchResults = ({ results, getInfo }: SearchResultsProps ) => {
   const seenBirds = new Set<string>();
   const maxUniqueBirds = 6;
   let uniqueBirds = 0;


### PR DESCRIPTION
## 🛠️ Description of this branch

* Renders Bird details on a new page based on what user clicks
* Shows more details than users see on the search results page

- [X] New Feature
- [ ] Fix
- [ ] Documentation
- [ ] Tests

## 🧠 Context or Rationale for this code
###### What is helpful for team to know and understand about decisions made in this code. 

We made a decision to not render the sono file. The sono file isn't very pretty nor adds much. The osci file is more interesting looking and is now the only file we suggest using for showing audio graphs. 

## 👀 Checks
- [X] When the project is run locally, the terminal shows no errors or warnings
- [X] Breaks nothing
- [ ] Breaks some things & Creates new issues
- [ ] Code in this branch has been tested  
- [X] Forgot to write new tests for changes in this code, but it is added to the project board as a ticket. 
- [ ] Code is DRY, reusable, follows SRP and trends toward function purity 
- [X] I've updated the project board to reflect changes, add issues, or tickets


## ✍🏽 Notes, Questions, What's Next
Needs some CSS help. 

## Screenshot
![image](https://github.com/sdmisra/birdWords/assets/117617970/a8e6a121-94bf-426b-8f70-1800649993bd)
