### PR TITLE
fix: Clean up details for props, and bird detail display

### DIFF
--- a/cypress/e2e/searchResults.cy.ts
+++ b/cypress/e2e/searchResults.cy.ts
@@ -1,22 +1,11 @@
-// describe('Search Results', () => {
-//    beforeEach(() => {
-//     cy.visit('http://localhost:3000/');
-//   });
-//   it('Does not do much!', () => {
-//     expect(true).to.equal(true)
-//   })
-// })
-
-
-// describe('Search Results from form', () => {
-//   beforeEach(() => {
-//     cy.visit('http://localhost:3000/');
-//   });
-// })
-
-
-describe('The Search Results Page', () => {
-  it('successfully loads the main page first', () => {
-    cy.visit('http://localhost:3000/') // change URL to match your dev URL
+describe('Search Results', () => {
+   beforeEach(() => {
+    cy.visit('http://localhost:3000/');
+  });
+  it('Does not do much!', () => {
+    expect(true).to.equal(true)
   })
 })
+
+
+

--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'react'
+import React, { Component } from 'react'
 import MainPage from '../MainPage/MainPage'
 import Header from '../Header/Header'
 import SearchResults from '../SearchResults/SearchResults'
@@ -20,14 +20,13 @@ type birdObject = {
   file: string;
   stage: string;
   sex: string;
-  songType: string;
+  type: string;
   loc: string;
   date: string;
   rec: string;
   also: string;
   rmk: string;
-  osci: string;
-  sono: string;
+  osci: {med: string};
 }
 
 class App extends Component<{}, AppState> {
@@ -35,10 +34,10 @@ class App extends Component<{}, AppState> {
     currentCnt: "",
     currentType: "",
     searchResults: [],
-    chosenBird: {id:'', en:'', cnt:'', file:'', stage:'', sex:'', songType:'', loc:'', date:'', rec:'', also:'',  rmk:'', osci:'', sono:'' }
-  }
+    chosenBird: {id:'', en:'', cnt:'', file:'', stage:'', sex:'', type:'', loc:'', date:'', rec:'', also:'',  rmk:'', osci: {med: '' }
+  }}
 
-  fetchResults = (event: React.MouseEvent<HTMLButtonElement>, formState: {selectedCnt : string, selectedType : string}) => {
+  fetchResults = (event: React.MouseEvent<HTMLButtonElement>, formState: {selectedCnt: string, selectedType: string}) => {
       event.preventDefault()
       FetchConditional(formState.selectedCnt, formState.selectedType)
       .then(data => {
@@ -52,7 +51,7 @@ class App extends Component<{}, AppState> {
     foundBird ? 
       this.setState({chosenBird: foundBird}) 
       : 
-      this.setState({chosenBird: {id:'', en:'', cnt:'', file:'', stage:'', sex:'', songType:'', loc:'', date:'', rec:'', also:'',  rmk:'', osci:'', sono:'' }});
+      this.setState({chosenBird: {id:'', en:'', cnt:'', file:'', stage:'', sex:'', type:'', loc:'', date:'', rec:'', also:'',  rmk:'', osci: {med:''}}});
 
     console.log('App state at time of click:', this.state.chosenBird);
   }
@@ -86,5 +85,7 @@ class App extends Component<{}, AppState> {
     )
 }
 }
+
+
 
 export default App;

--- a/src/Components/BirdInfo/BirdInfo.css
+++ b/src/Components/BirdInfo/BirdInfo.css
@@ -9,14 +9,18 @@
 .bird-data-container {
   border: .2rem solid#4B7F52;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   flex-direction: column;
   border-radius: 10px;
-  min-width: 40%;
+  max-width: 20%;
   height: 80%;
-  align-items: center;
+  align-items: flex-start;
+  padding: 3rem;
   margin: 2rem;
+}
 
+h3 {
+  text-transform: uppercase;
 }
 
 .audio-details-container {

--- a/src/Components/BirdInfo/BirdInfo.tsx
+++ b/src/Components/BirdInfo/BirdInfo.tsx
@@ -25,22 +25,18 @@ type birdObject = {
 const BirdInfo = ({ chosenBird }:
 BirdProps ) => {
 
+
   console.log("Chosen", chosenBird)
     return ( 
       <div className="info-container">
         <img className="bird" src={assets} alt="two birds looking at you from a branch"></img>
         <section className="bird-data-container">
-          <h2>{chosenBird.en}</h2>
-          <p></p>
-          <p>{chosenBird.stage}</p>
-          <p>{chosenBird.sex}</p>
+          <h3>{chosenBird.en}</h3>
+          <p>{chosenBird.stage} {chosenBird.sex}</p>
           <p>{chosenBird.type}</p>
-            <p>In the background listen for: {chosenBird.also}</p>
-          <p>Recorded in {chosenBird.cnt} at {chosenBird.loc}</p>
-          <p>on {chosenBird.date}</p>
+          <p>Recorded in {chosenBird.cnt} at {chosenBird.loc} on {chosenBird.date}</p>
           <p>Recorded by {chosenBird.rec}</p>
-          <p>Notes from the recorder: {chosenBird.rmk}</p>
-        
+          <p style={{fontStyle: "italic"}}>{chosenBird.rmk}</p>
         </section>
         <section className="audio-details-container">
           <audio src={chosenBird.file} controls className="bird-info-audio"></audio>


### PR DESCRIPTION
## 🛠️ Description of this branch

* Fixes some of the props as they pass down to bird detail page
* Rearranges details so they render in a more pleasing way
* 

- [ ] New Feature
- [X] Fix
- [ ] Documentation
- [ ] Tests

## 🧠 Context or Rationale for this code
###### What is helpful for team to know and understand about decisions made in this code. 
Until we make a separate file for the props and typestyles, this branch adds a few needed little  things like: osci: {med: string} in a couple more places. Also changed the HTML on BirdInfo slightly to rearrange some of the information and to better display if no information was included. For instance, many times there are no "background singers" in the data, and so it left that hanging when it said, "Background singers you may also hear:". We could work into the cleaning function to find recordings that a) have notes from the recorder (rmk) and/ or b) background singers (also). Otherwise how I've changed it here leaves out background singers and puts remarks in italics, but does not have a description of what it is. As is works fine without any needed changes elsewhere. 

## 👀 Checks
- [X] When the project is run locally, the terminal shows no errors or warnings
- [X] Breaks nothing
- [ ] Breaks some things & Creates new issues
- [ ] Code in this branch has been tested  
- [ ] Forgot to write new tests for changes in this code, but it is added to the project board as a ticket. 
- [ ] Code is DRY, reusable, follows SRP and trends toward function purity 
- [ ] I've updated the project board to reflect changes, add issues, or tickets


## ✍🏽 Notes, Questions, What's Next


## Screenshot
![image](https://github.com/sdmisra/birdWords/assets/117617970/34059575-e309-497c-8baf-17b20d7d94c0)
